### PR TITLE
Supports non generics APIs

### DIFF
--- a/src/ValueTaskSupplement/ValueTaskEx.Lazy_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.Lazy_NonGenerics.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask Lazy(Func<ValueTask> factory)
+        {
+            return new ValueTask(new AsyncLazySource(factory), 0);
+        }
+
+        class AsyncLazySource : IValueTaskSource
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            Func<ValueTask> factory;
+            object syncLock;
+            ValueTask source;
+            bool initialized;
+
+            public AsyncLazySource(Func<ValueTask> factory)
+            {
+                this.factory = factory;
+                this.syncLock = new object();
+            }
+
+            ValueTask GetSource()
+            {
+                return LazyInitializer.EnsureInitialized(ref source, ref initialized, ref syncLock, factory);
+            }
+
+            public void GetResult(short token)
+            {
+                GetSource().GetAwaiter().GetResult();
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                var task = GetSource();
+                return task.IsCompletedSuccessfully ? ValueTaskSourceStatus.Succeeded
+                    : task.IsCanceled ? ValueTaskSourceStatus.Canceled
+                    : task.IsFaulted ? ValueTaskSourceStatus.Faulted
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                var task = GetSource();
+                if (task.IsCompleted)
+                {
+                    continuation(state);
+                }
+                OnCompletedSlow(task, continuation, state, flags);
+            }
+
+            static async void OnCompletedSlow(ValueTask source, Action<object> continuation, object state, ValueTaskSourceOnCompletedFlags flags)
+            {
+                ExecutionContext execContext = null;
+                SynchronizationContext syncContext = null;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                await source.ConfigureAwait(false);
+
+                if (execContext != null)
+                {
+                    ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(continuation, state, syncContext));
+                }
+                else if (syncContext != null)
+                {
+                    syncContext.Post(syncContextCallback, Tuple.Create(continuation, state, syncContext));
+                }
+                else
+                {
+                    continuation(state);
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, object, SynchronizationContext>)state;
+                if (t.Item3 != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    t.Item1.Invoke(t.Item2);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, object, SynchronizationContext>)state;
+                t.Item1.Invoke(t.Item2);
+            }
+        }
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAll_Array_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAll_Array_NonGenerics.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask WhenAll(IEnumerable<ValueTask> tasks)
+        {
+            return new ValueTask(new WhenAllPromiseAll(tasks), 0);
+        }
+
+        class WhenAllPromiseAll : IValueTaskSource
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+            
+            int taskCount = 0;
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromiseAll(IEnumerable<ValueTask> tasks)
+            {
+                if (tasks is ValueTask[] array)
+                {
+                    Run(array);
+                    return;
+                }
+                if (tasks is IReadOnlyCollection<ValueTask> c)
+                {
+                    Run(c, c.Count);
+                    return;
+                }
+                if (tasks is ICollection<ValueTask> c2)
+                {
+                    Run(c2, c2.Count);
+                    return;
+                }
+
+                var list = new TempList<ValueTask>(99);
+                try
+                {
+                    foreach (var item in tasks)
+                    {
+                        list.Add(item);
+                    }
+
+                    Run(list.AsSpan());
+                }
+                finally
+                {
+                    list.Dispose();
+                }
+            }
+
+            void Run(ReadOnlySpan<ValueTask> tasks)
+            {
+                taskCount = tasks.Length;
+
+                var i = 0;
+                foreach (var task in tasks)
+                {
+                    var awaiter = task.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        RegisterContinuation(awaiter, i);
+                    }
+
+                    i++;
+                }
+            }
+
+            void Run(IEnumerable<ValueTask> tasks, int length)
+            {
+                taskCount = length;
+
+                var i = 0;
+                foreach (var task in tasks)
+                {
+                    var awaiter = task.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        RegisterContinuation(awaiter, i);
+                    }
+
+                    i++;
+                }
+            }
+
+            void RegisterContinuation(ValueTaskAwaiter awaiter, int index)
+            {
+                awaiter.UnsafeOnCompleted(() =>
+                {
+                    try
+                    {
+                        awaiter.GetResult();
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ExceptionDispatchInfo.Capture(ex);
+                        TryInvokeContinuation();
+                        return;
+                    }
+                    TryInvokeContinuationWithIncrement();
+                });
+            }
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == taskCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == taskCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromiseAll>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromiseAll>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAll_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAll_NonGenerics.cs
@@ -1,0 +1,6913 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise2(task0, task1), 0);
+        }
+
+        class WhenAllPromise2 : IValueTaskSource
+        {
+            const int ResultCount = 2;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise2(ValueTask task0, ValueTask task1)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise2>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise2>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise3(task0, task1, task2), 0);
+        }
+
+        class WhenAllPromise3 : IValueTaskSource
+        {
+            const int ResultCount = 3;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise3(ValueTask task0, ValueTask task1, ValueTask task2)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise3>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise3>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise4(task0, task1, task2, task3), 0);
+        }
+
+        class WhenAllPromise4 : IValueTaskSource
+        {
+            const int ResultCount = 4;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise4(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise4>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise4>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise5(task0, task1, task2, task3, task4), 0);
+        }
+
+        class WhenAllPromise5 : IValueTaskSource
+        {
+            const int ResultCount = 5;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise5(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise5>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise5>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise6(task0, task1, task2, task3, task4, task5), 0);
+        }
+
+        class WhenAllPromise6 : IValueTaskSource
+        {
+            const int ResultCount = 6;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise6(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise6>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise6>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise7(task0, task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        class WhenAllPromise7 : IValueTaskSource
+        {
+            const int ResultCount = 7;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise7(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise7>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise7>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise8(task0, task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        class WhenAllPromise8 : IValueTaskSource
+        {
+            const int ResultCount = 8;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise8(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise8>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise8>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise9(task0, task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        class WhenAllPromise9 : IValueTaskSource
+        {
+            const int ResultCount = 9;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise9(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise9>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise9>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise10(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        class WhenAllPromise10 : IValueTaskSource
+        {
+            const int ResultCount = 10;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise10(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise10>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise10>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise11(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        class WhenAllPromise11 : IValueTaskSource
+        {
+            const int ResultCount = 11;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise11(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise11>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise11>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully && task11.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise12(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        class WhenAllPromise12 : IValueTaskSource
+        {
+            const int ResultCount = 12;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise12(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise12>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise12>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully && task11.IsCompletedSuccessfully && task12.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise13(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        class WhenAllPromise13 : IValueTaskSource
+        {
+            const int ResultCount = 13;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise13(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise13>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise13>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully && task11.IsCompletedSuccessfully && task12.IsCompletedSuccessfully && task13.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise14(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        class WhenAllPromise14 : IValueTaskSource
+        {
+            const int ResultCount = 14;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise14(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise14>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise14>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully && task11.IsCompletedSuccessfully && task12.IsCompletedSuccessfully && task13.IsCompletedSuccessfully && task14.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise15(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        class WhenAllPromise15 : IValueTaskSource
+        {
+            const int ResultCount = 15;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+            ValueTaskAwaiter awaiter14;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise15(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter14 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation14);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation14()
+            {
+                try
+                {
+                    awaiter14.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise15>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise15>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask WhenAll(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14, ValueTask task15)
+        {
+            if (task0.IsCompletedSuccessfully && task1.IsCompletedSuccessfully && task2.IsCompletedSuccessfully && task3.IsCompletedSuccessfully && task4.IsCompletedSuccessfully && task5.IsCompletedSuccessfully && task6.IsCompletedSuccessfully && task7.IsCompletedSuccessfully && task8.IsCompletedSuccessfully && task9.IsCompletedSuccessfully && task10.IsCompletedSuccessfully && task11.IsCompletedSuccessfully && task12.IsCompletedSuccessfully && task13.IsCompletedSuccessfully && task14.IsCompletedSuccessfully && task15.IsCompletedSuccessfully)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise16(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        class WhenAllPromise16 : IValueTaskSource
+        {
+            const int ResultCount = 16;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+            ValueTaskAwaiter awaiter14;
+            ValueTaskAwaiter awaiter15;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise16(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14, ValueTask task15)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter14 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation14);
+                    }
+                }
+                {
+                    var awaiter = task15.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter15 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation15);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation14()
+            {
+                try
+                {
+                    awaiter14.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+            void Continuation15()
+            {
+                try
+                {
+                    awaiter15.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise16>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise16>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAll_NonGenerics.tt
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAll_NonGenerics.tt
@@ -1,0 +1,198 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+<# for(var i = 1; i <= 15; i++ ) {
+    var range = Enumerable.Range(0, i + 1);
+    var args = string.Join(", ", range.Select(x => $"ValueTask task{x}"));
+    var targs = string.Join(", ", range.Select(x => $"task{x}"));
+    var tresult = string.Join(", ", range.Select(x => $"task{x}.Result"));
+    var completedSuccessfullyAnd = string.Join(" && ", range.Select(x => $"task{x}.IsCompletedSuccessfully"));
+    var tfield = string.Join(", ", range.Select(x => $"t{x}"));
+#>
+        public static ValueTask WhenAll(<#= args #>)
+        {
+            if (<#= completedSuccessfullyAnd #>)
+            {
+                return default;
+            }
+
+            return new ValueTask(new WhenAllPromise<#= i + 1 #>(<#= targs #>), 0);
+        }
+
+        class WhenAllPromise<#= i + 1 #> : IValueTaskSource
+        {
+            const int ResultCount = <#= i + 1 #>;
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+<# for(var j = 0; j <= i; j++) { #>
+            ValueTaskAwaiter awaiter<#= j #>;
+<# } #>
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAllPromise<#= i + 1 #>(<#= args #>)
+            {
+<# for(var j = 0; j <= i; j++) { #>
+                {
+                    var awaiter = task<#= j #>.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                        TryInvokeContinuationWithIncrement();
+                    }
+                    else
+                    {
+                        awaiter<#= j #> = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation<#= j #>);
+                    }
+                }
+<# } #>
+            }
+
+<# for(var j = 0; j <= i; j++) { #>
+            void Continuation<#= j #>()
+            {
+                try
+                {
+                    awaiter<#= j #>.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement();
+            }
+
+<# } #>
+
+            void TryInvokeContinuationWithIncrement()
+            {
+                if (Interlocked.Increment(ref completedCount) == ResultCount)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public void GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (completedCount == ResultCount) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise<#= i + 1 #>>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAllPromise<#= i + 1 #>>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+<# } #>
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAny_Array_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAny_Array_NonGenerics.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask<int> WhenAny(IEnumerable<ValueTask> tasks)
+        {
+            return new ValueTask<int>(new WhenAnyPromiseAll(tasks), 0);
+        }
+
+        class WhenAnyPromiseAll : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            int completedCount = 0;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            int winArgumentIndex = -1;
+
+            public WhenAnyPromiseAll(IEnumerable<ValueTask> tasks)
+            {
+                var i = 0;
+                foreach (var task in tasks)
+                {
+                    var awaiter = task.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIndex(i);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        RegisterContinuation(awaiter, i);
+                    }
+
+                    i++;
+                }
+            }
+
+            void RegisterContinuation(ValueTaskAwaiter awaiter, int index)
+            {
+                awaiter.UnsafeOnCompleted(() =>
+                {
+                    try
+                    {
+                        awaiter.GetResult();
+                        TryInvokeContinuationWithIndex(index);
+                        return;
+                    }
+                    catch (Exception ex)
+                    {
+                        exception = ExceptionDispatchInfo.Capture(ex);
+                        TryInvokeContinuation();
+                        return;
+                    }
+                });
+            }
+
+            void TryInvokeContinuationWithIndex(int winIndex)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, winIndex);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromiseAll>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromiseAll>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAny_Array_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAny_Array_NonGenerics.cs
@@ -10,6 +10,11 @@ namespace ValueTaskSupplement
 {
     public static partial class ValueTaskEx
     {
+        public static ValueTask<int> WhenAny(ValueTask left, Task right)
+        {
+            return new ValueTask<int>(new WhenAnyPromise2(left, new ValueTask(right)), 0);
+        }
+
         public static ValueTask<int> WhenAny(IEnumerable<ValueTask> tasks)
         {
             return new ValueTask<int>(new WhenAnyPromiseAll(tasks), 0);

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAny_NonGenerics.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAny_NonGenerics.cs
@@ -1,0 +1,7003 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1)
+        {
+            return new ValueTask<int>(new WhenAnyPromise2(task0, task1), 0);
+        }
+
+        class WhenAnyPromise2 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise2(ValueTask task0, ValueTask task1)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise2>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise2>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2)
+        {
+            return new ValueTask<int>(new WhenAnyPromise3(task0, task1, task2), 0);
+        }
+
+        class WhenAnyPromise3 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise3(ValueTask task0, ValueTask task1, ValueTask task2)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise3>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise3>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3)
+        {
+            return new ValueTask<int>(new WhenAnyPromise4(task0, task1, task2, task3), 0);
+        }
+
+        class WhenAnyPromise4 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise4(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise4>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise4>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4)
+        {
+            return new ValueTask<int>(new WhenAnyPromise5(task0, task1, task2, task3, task4), 0);
+        }
+
+        class WhenAnyPromise5 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise5(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise5>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise5>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5)
+        {
+            return new ValueTask<int>(new WhenAnyPromise6(task0, task1, task2, task3, task4, task5), 0);
+        }
+
+        class WhenAnyPromise6 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise6(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise6>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise6>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6)
+        {
+            return new ValueTask<int>(new WhenAnyPromise7(task0, task1, task2, task3, task4, task5, task6), 0);
+        }
+
+        class WhenAnyPromise7 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise7(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise7>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise7>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7)
+        {
+            return new ValueTask<int>(new WhenAnyPromise8(task0, task1, task2, task3, task4, task5, task6, task7), 0);
+        }
+
+        class WhenAnyPromise8 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise8(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise8>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise8>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8)
+        {
+            return new ValueTask<int>(new WhenAnyPromise9(task0, task1, task2, task3, task4, task5, task6, task7, task8), 0);
+        }
+
+        class WhenAnyPromise9 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise9(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise9>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise9>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9)
+        {
+            return new ValueTask<int>(new WhenAnyPromise10(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9), 0);
+        }
+
+        class WhenAnyPromise10 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise10(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise10>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise10>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10)
+        {
+            return new ValueTask<int>(new WhenAnyPromise11(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10), 0);
+        }
+
+        class WhenAnyPromise11 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise11(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise11>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise11>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11)
+        {
+            return new ValueTask<int>(new WhenAnyPromise12(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11), 0);
+        }
+
+        class WhenAnyPromise12 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise12(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(11);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(11);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise12>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise12>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12)
+        {
+            return new ValueTask<int>(new WhenAnyPromise13(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12), 0);
+        }
+
+        class WhenAnyPromise13 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise13(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(11);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(12);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(11);
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(12);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise13>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise13>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13)
+        {
+            return new ValueTask<int>(new WhenAnyPromise14(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13), 0);
+        }
+
+        class WhenAnyPromise14 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise14(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(11);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(12);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(13);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(11);
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(12);
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(13);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise14>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise14>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14)
+        {
+            return new ValueTask<int>(new WhenAnyPromise15(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14), 0);
+        }
+
+        class WhenAnyPromise15 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+            ValueTaskAwaiter awaiter14;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise15(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(11);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(12);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(13);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(14);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter14 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation14);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(11);
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(12);
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(13);
+            }
+
+            void Continuation14()
+            {
+                try
+                {
+                    awaiter14.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(14);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise15>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise15>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+        public static ValueTask<int> WhenAny(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14, ValueTask task15)
+        {
+            return new ValueTask<int>(new WhenAnyPromise16(task0, task1, task2, task3, task4, task5, task6, task7, task8, task9, task10, task11, task12, task13, task14, task15), 0);
+        }
+
+        class WhenAnyPromise16 : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+            ValueTaskAwaiter awaiter0;
+            ValueTaskAwaiter awaiter1;
+            ValueTaskAwaiter awaiter2;
+            ValueTaskAwaiter awaiter3;
+            ValueTaskAwaiter awaiter4;
+            ValueTaskAwaiter awaiter5;
+            ValueTaskAwaiter awaiter6;
+            ValueTaskAwaiter awaiter7;
+            ValueTaskAwaiter awaiter8;
+            ValueTaskAwaiter awaiter9;
+            ValueTaskAwaiter awaiter10;
+            ValueTaskAwaiter awaiter11;
+            ValueTaskAwaiter awaiter12;
+            ValueTaskAwaiter awaiter13;
+            ValueTaskAwaiter awaiter14;
+            ValueTaskAwaiter awaiter15;
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise16(ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14, ValueTask task15)
+            {
+                {
+                    var awaiter = task0.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(0);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter0 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation0);
+                    }
+                }
+                {
+                    var awaiter = task1.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(1);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter1 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation1);
+                    }
+                }
+                {
+                    var awaiter = task2.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(2);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter2 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation2);
+                    }
+                }
+                {
+                    var awaiter = task3.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(3);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter3 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation3);
+                    }
+                }
+                {
+                    var awaiter = task4.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(4);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter4 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation4);
+                    }
+                }
+                {
+                    var awaiter = task5.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(5);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter5 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation5);
+                    }
+                }
+                {
+                    var awaiter = task6.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(6);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter6 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation6);
+                    }
+                }
+                {
+                    var awaiter = task7.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(7);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter7 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation7);
+                    }
+                }
+                {
+                    var awaiter = task8.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(8);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter8 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation8);
+                    }
+                }
+                {
+                    var awaiter = task9.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(9);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter9 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation9);
+                    }
+                }
+                {
+                    var awaiter = task10.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(10);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter10 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation10);
+                    }
+                }
+                {
+                    var awaiter = task11.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(11);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter11 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation11);
+                    }
+                }
+                {
+                    var awaiter = task12.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(12);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter12 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation12);
+                    }
+                }
+                {
+                    var awaiter = task13.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(13);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter13 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation13);
+                    }
+                }
+                {
+                    var awaiter = task14.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(14);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter14 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation14);
+                    }
+                }
+                {
+                    var awaiter = task15.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(15);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter15 = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation15);
+                    }
+                }
+            }
+
+            void Continuation0()
+            {
+                try
+                {
+                    awaiter0.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(0);
+            }
+
+            void Continuation1()
+            {
+                try
+                {
+                    awaiter1.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(1);
+            }
+
+            void Continuation2()
+            {
+                try
+                {
+                    awaiter2.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(2);
+            }
+
+            void Continuation3()
+            {
+                try
+                {
+                    awaiter3.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(3);
+            }
+
+            void Continuation4()
+            {
+                try
+                {
+                    awaiter4.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(4);
+            }
+
+            void Continuation5()
+            {
+                try
+                {
+                    awaiter5.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(5);
+            }
+
+            void Continuation6()
+            {
+                try
+                {
+                    awaiter6.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(6);
+            }
+
+            void Continuation7()
+            {
+                try
+                {
+                    awaiter7.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(7);
+            }
+
+            void Continuation8()
+            {
+                try
+                {
+                    awaiter8.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(8);
+            }
+
+            void Continuation9()
+            {
+                try
+                {
+                    awaiter9.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(9);
+            }
+
+            void Continuation10()
+            {
+                try
+                {
+                    awaiter10.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(10);
+            }
+
+            void Continuation11()
+            {
+                try
+                {
+                    awaiter11.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(11);
+            }
+
+            void Continuation12()
+            {
+                try
+                {
+                    awaiter12.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(12);
+            }
+
+            void Continuation13()
+            {
+                try
+                {
+                    awaiter13.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(13);
+            }
+
+            void Continuation14()
+            {
+                try
+                {
+                    awaiter14.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(14);
+            }
+
+            void Continuation15()
+            {
+                try
+                {
+                    awaiter15.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(15);
+            }
+
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise16>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise16>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskEx.WhenAny_NonGenerics.tt
+++ b/src/ValueTaskSupplement/ValueTaskEx.WhenAny_NonGenerics.tt
@@ -1,0 +1,195 @@
+﻿<#@ template debug="false" hostspecific="false" language="C#" #>
+<#@ assembly name="System.Core" #>
+<#@ import namespace="System.Linq" #>
+<#@ import namespace="System.Text" #>
+<#@ import namespace="System.Collections.Generic" #>
+<#@ output extension=".cs" #>
+using System;
+using System.Runtime.CompilerServices;
+using System.Runtime.ExceptionServices;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Threading.Tasks.Sources;
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+<# for(var i = 1; i <= 15; i++ ) {
+    var range = Enumerable.Range(0, i + 1);
+    var ttuple = string.Join(", ", range.Select(x => $"T{x} result{x}"));
+    var args = string.Join(", ", range.Select(x => $"ValueTask task{x}"));
+    var targs = string.Join(", ", range.Select(x => $"task{x}"));
+    var tresultTuple = string.Join(", ", range.Select(x => $"t{x}"));
+#>
+        public static ValueTask<int> WhenAny(<#= args #>)
+        {
+            return new ValueTask<int>(new WhenAnyPromise<#= i + 1 #>(<#= targs #>), 0);
+        }
+
+        class WhenAnyPromise<#= i + 1 #> : IValueTaskSource<int>
+        {
+            static readonly ContextCallback execContextCallback = ExecutionContextCallback;
+            static readonly SendOrPostCallback syncContextCallback = SynchronizationContextCallback;
+
+<# for(var j = 0; j <= i; j++) { #>
+            ValueTaskAwaiter awaiter<#= j #>;
+<# } #>
+
+            int completedCount = 0;
+            int winArgumentIndex = -1;
+            ExceptionDispatchInfo exception;
+            Action<object> continuation = ContinuationSentinel.AvailableContinuation;
+            object state;
+            SynchronizationContext syncContext;
+            ExecutionContext execContext;
+
+            public WhenAnyPromise<#= i + 1 #>(<#= args #>)
+            {
+<# for(var j = 0; j <= i; j++) { #>
+                {
+                    var awaiter = task<#= j #>.GetAwaiter();
+                    if (awaiter.IsCompleted)
+                    {
+                        try
+                        {
+                            awaiter.GetResult();
+                            TryInvokeContinuationWithIncrement(<#= j #>);
+                            return;
+                        }
+                        catch (Exception ex)
+                        {
+                            exception = ExceptionDispatchInfo.Capture(ex);
+                            return;
+                        }
+                    }
+                    else
+                    {
+                        awaiter<#= j #> = awaiter;
+                        awaiter.UnsafeOnCompleted(Continuation<#= j #>);
+                    }
+                }
+<# } #>
+            }
+
+<# for(var j = 0; j <= i; j++) { #>
+            void Continuation<#= j #>()
+            {
+                try
+                {
+                    awaiter<#= j #>.GetResult();
+                }
+                catch (Exception ex)
+                {
+                    exception = ExceptionDispatchInfo.Capture(ex);
+                    TryInvokeContinuation();
+                    return;
+                }
+                TryInvokeContinuationWithIncrement(<#= j #>);
+            }
+
+<# } #>
+
+            void TryInvokeContinuationWithIncrement(int index)
+            {
+                if (Interlocked.Increment(ref completedCount) == 1)
+                {
+                    Volatile.Write(ref winArgumentIndex, index);
+                    TryInvokeContinuation();
+                }
+            }
+
+            void TryInvokeContinuation()
+            {
+                var c = Interlocked.Exchange(ref continuation, ContinuationSentinel.CompletedContinuation);
+                if (c != ContinuationSentinel.AvailableContinuation && c != ContinuationSentinel.CompletedContinuation)
+                {
+                    var spinWait = new SpinWait();
+                    while (state == null) // worst case, state is not set yet so wait.
+                    {
+                        spinWait.SpinOnce();
+                    }
+
+                    if (execContext != null)
+                    {
+                        ExecutionContext.Run(execContext, execContextCallback, Tuple.Create(c, this));
+                    }
+                    else if (syncContext != null)
+                    {
+                        syncContext.Post(syncContextCallback, Tuple.Create(c, this));
+                    }
+                    else
+                    {
+                        c(state);
+                    }
+                }
+            }
+
+            public int GetResult(short token)
+            {
+                if (exception != null)
+                {
+                    exception.Throw();
+                }
+                return winArgumentIndex;
+            }
+
+            public ValueTaskSourceStatus GetStatus(short token)
+            {
+                return (Volatile.Read(ref winArgumentIndex) != -1) ? ValueTaskSourceStatus.Succeeded
+                    : (exception != null) ? ((exception.SourceException is OperationCanceledException) ? ValueTaskSourceStatus.Canceled : ValueTaskSourceStatus.Faulted)
+                    : ValueTaskSourceStatus.Pending;
+            }
+
+            public void OnCompleted(Action<object> continuation, object state, short token, ValueTaskSourceOnCompletedFlags flags)
+            {
+                if (Interlocked.CompareExchange(ref this.continuation, continuation, ContinuationSentinel.AvailableContinuation) != ContinuationSentinel.AvailableContinuation)
+                {
+                    throw new InvalidOperationException("does not allow multiple await.");
+                }
+
+                this.state = state;
+                if ((flags & ValueTaskSourceOnCompletedFlags.FlowExecutionContext) == ValueTaskSourceOnCompletedFlags.FlowExecutionContext)
+                {
+                    execContext = ExecutionContext.Capture();
+                }
+                if ((flags & ValueTaskSourceOnCompletedFlags.UseSchedulingContext) == ValueTaskSourceOnCompletedFlags.UseSchedulingContext)
+                {
+                    syncContext = SynchronizationContext.Current;
+                }
+
+                if (GetStatus(token) != ValueTaskSourceStatus.Pending)
+                {
+                    TryInvokeContinuation();
+                }
+            }
+
+            static void ExecutionContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise<#= i + 1 #>>)state;
+                var self = t.Item2;
+                if (self.syncContext != null)
+                {
+                    SynchronizationContextCallback(state);
+                }
+                else
+                {
+                    var invokeState = self.state;
+                    self.state = null;
+                    t.Item1.Invoke(invokeState);
+                }
+            }
+
+            static void SynchronizationContextCallback(object state)
+            {
+                var t = (Tuple<Action<object>, WhenAnyPromise<#= i + 1 #>>)state;
+                var self = t.Item2;
+                var invokeState = self.state;
+                self.state = null;
+                t.Item1.Invoke(invokeState);
+            }
+        }
+
+<# } #>
+    }
+}

--- a/src/ValueTaskSupplement/ValueTaskSupplement.csproj
+++ b/src/ValueTaskSupplement/ValueTaskSupplement.csproj
@@ -28,12 +28,20 @@
 
     <ItemGroup>
         <None Update="ValueTaskEx.WhenAll.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ValueTaskEx.WhenAll.cs</LastGenOutput>
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>ValueTaskEx.WhenAll.cs</LastGenOutput>
+        </None>
+        <None Update="ValueTaskEx.WhenAll_NonGenerics.tt">
+          <LastGenOutput>ValueTaskEx.WhenAll_NonGenerics.cs</LastGenOutput>
+          <Generator>TextTemplatingFileGenerator</Generator>
         </None>
         <None Update="ValueTaskEx.WhenAny.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ValueTaskEx.WhenAny.cs</LastGenOutput>
+          <Generator>TextTemplatingFileGenerator</Generator>
+          <LastGenOutput>ValueTaskEx.WhenAny.cs</LastGenOutput>
+        </None>
+        <None Update="ValueTaskEx.WhenAny_NonGenerics.tt">
+          <LastGenOutput>ValueTaskEx.WhenAny_NonGenerics.cs</LastGenOutput>
+          <Generator>TextTemplatingFileGenerator</Generator>
         </None>
         <None Update="ValueTaskWhenAllExtensions.tt">
           <Generator>TextTemplatingFileGenerator</Generator>
@@ -43,14 +51,24 @@
 
     <ItemGroup>
         <Compile Update="ValueTaskEx.WhenAll.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAll.tt</DependentUpon>
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>ValueTaskEx.WhenAll.tt</DependentUpon>
+        </Compile>
+        <Compile Update="ValueTaskEx.WhenAll_NonGenerics.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>ValueTaskEx.WhenAll_NonGenerics.tt</DependentUpon>
         </Compile>
         <Compile Update="ValueTaskEx.WhenAny.cs">
+          <DesignTime>True</DesignTime>
+          <AutoGen>True</AutoGen>
+          <DependentUpon>ValueTaskEx.WhenAny.tt</DependentUpon>
+        </Compile>
+        <Compile Update="ValueTaskEx.WhenAny_NonGenerics.cs">
             <DesignTime>True</DesignTime>
             <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAny.tt</DependentUpon>
+            <DependentUpon>ValueTaskEx.WhenAny_NonGenerics.tt</DependentUpon>
         </Compile>
         <Compile Update="ValueTaskWhenAllExtensions.cs">
           <DesignTime>True</DesignTime>

--- a/src/ValueTaskSupplement/ValueTaskWhenAllExtensions.cs
+++ b/src/ValueTaskSupplement/ValueTaskWhenAllExtensions.cs
@@ -6,6 +6,7 @@ namespace ValueTaskSupplement
 {
     public static class ValueTaskWhenAllExtensions
     {
+        #region Generics
         public static ValueTaskAwaiter<T[]> GetAwaiter<T>(this IEnumerable<ValueTask<T>> tasks)
         {
             return ValueTaskEx.WhenAll(tasks).GetAwaiter();
@@ -85,5 +86,88 @@ namespace ValueTaskSupplement
         {
             return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14, tasks.Item15, tasks.Item16).GetAwaiter();
         }
+        #endregion
+
+        #region Non Generics
+        public static ValueTaskAwaiter GetAwaiter(this IEnumerable<ValueTask> tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14, tasks.Item15).GetAwaiter();
+        }
+
+        public static ValueTaskAwaiter GetAwaiter(this (ValueTask task0, ValueTask task1, ValueTask task2, ValueTask task3, ValueTask task4, ValueTask task5, ValueTask task6, ValueTask task7, ValueTask task8, ValueTask task9, ValueTask task10, ValueTask task11, ValueTask task12, ValueTask task13, ValueTask task14, ValueTask task15) tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks.Item1, tasks.Item2, tasks.Item3, tasks.Item4, tasks.Item5, tasks.Item6, tasks.Item7, tasks.Item8, tasks.Item9, tasks.Item10, tasks.Item11, tasks.Item12, tasks.Item13, tasks.Item14, tasks.Item15, tasks.Item16).GetAwaiter();
+        }
+        #endregion
     }
 }

--- a/src/ValueTaskSupplement/ValueTaskWhenAllExtensions.tt
+++ b/src/ValueTaskSupplement/ValueTaskWhenAllExtensions.tt
@@ -12,6 +12,7 @@ namespace ValueTaskSupplement
 {
     public static class ValueTaskWhenAllExtensions
     {
+        #region Generics
         public static ValueTaskAwaiter<T[]> GetAwaiter<T>(this IEnumerable<ValueTask<T>> tasks)
         {
             return ValueTaskEx.WhenAll(tasks).GetAwaiter();
@@ -28,5 +29,24 @@ namespace ValueTaskSupplement
             return ValueTaskEx.WhenAll(<#= itemx #>).GetAwaiter();
         }
 <# }#>
+        #endregion
+
+        #region Non Generics
+        public static ValueTaskAwaiter GetAwaiter(this IEnumerable<ValueTask> tasks)
+        {
+            return ValueTaskEx.WhenAll(tasks).GetAwaiter();
+        }
+<# for(var i = 1; i <= 15; i++) { 
+    var range = Enumerable.Range(0, i + 1);
+    var args = string.Join(", ", range.Select(x => $"ValueTask task{x}"));
+    var itemx = string.Join(", ", range.Select(x => $"tasks.Item{x + 1}"));
+#>
+
+        public static ValueTaskAwaiter GetAwaiter(this (<#= args #>) tasks)
+        {
+            return ValueTaskEx.WhenAll(<#= itemx #>).GetAwaiter();
+        }
+<# }#>
+        #endregion
     }
 }

--- a/tests/ValueTaskSupplement.Tests/LazyTest.cs
+++ b/tests/ValueTaskSupplement.Tests/LazyTest.cs
@@ -28,7 +28,7 @@ namespace ValueTaskSupplement.Tests
         }
 
         [Fact]
-        public async Task ASync()
+        public async Task Async()
         {
             var calledCount = 0;
             var syncLazy = ValueTaskEx.Lazy(async () => { calledCount++; await Task.Delay(TimeSpan.FromSeconds(1)); return new object(); });

--- a/tests/ValueTaskSupplement.Tests/LazyTest_NonGenerics.cs
+++ b/tests/ValueTaskSupplement.Tests/LazyTest_NonGenerics.cs
@@ -1,0 +1,39 @@
+#pragma warning disable CS1998
+
+using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace ValueTaskSupplement.Tests
+{
+    public class LazyTest_NonGenerics
+    {
+        [Fact]
+        public async Task Sync()
+        {
+            var calledCount = 0;
+            var syncLazy = ValueTaskEx.Lazy(async () => { calledCount++; });
+
+            calledCount.Should().Be(0);
+
+            await syncLazy;
+            calledCount.Should().Be(1);
+
+            await syncLazy;
+            calledCount.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Async()
+        {
+            var calledCount = 0;
+            var syncLazy = ValueTaskEx.Lazy(async () => { calledCount++; await Task.Delay(TimeSpan.FromSeconds(1)); });
+            calledCount.Should().Be(0);
+
+            await ValueTaskEx.WhenAll(syncLazy, syncLazy, syncLazy);
+
+            calledCount.Should().Be(1);
+        }
+    }
+}

--- a/tests/ValueTaskSupplement.Tests/WhenAllTest_NonGenerics.cs
+++ b/tests/ValueTaskSupplement.Tests/WhenAllTest_NonGenerics.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace ValueTaskSupplement.Tests
+{
+    public class WhenAllTest_NonGenerics
+    {
+        [Fact]
+        public async Task AllSync()
+        {
+            var a = CreateSync();
+            var b = CreateSync();
+            var c = CreateSync();
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeTrue();
+            c.IsCompletedSuccessfully.Should().BeTrue();
+
+            await ValueTaskEx.WhenAll(a, b, c);
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeTrue();
+            c.IsCompletedSuccessfully.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task WithAsync()
+        {
+            var a = CreateSync();
+            var b = CreateAsync();
+            var c = CreateAsync();
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeFalse();
+            c.IsCompletedSuccessfully.Should().BeFalse();
+
+            await ValueTaskEx.WhenAll(a, b, c);
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeTrue();
+            c.IsCompletedSuccessfully.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Array()
+        {
+            var a = CreateSync();
+            var b = CreateAsync();
+            var c = CreateAsync();
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeFalse();
+            c.IsCompletedSuccessfully.Should().BeFalse();
+
+            await ValueTaskEx.WhenAll(new[] { a, b, c });
+
+            a.IsCompletedSuccessfully.Should().BeTrue();
+            b.IsCompletedSuccessfully.Should().BeTrue();
+            c.IsCompletedSuccessfully.Should().BeTrue();
+        }
+
+        [Fact]
+        public async Task Extension()
+        {
+            await new[] { CreateAsync(), CreateAsync(), CreateAsync() };
+            await (CreateAsync(), CreateAsync());
+        }
+
+        ValueTask CreateSync()
+        {
+            return new ValueTask();
+        }
+
+        async ValueTask CreateAsync()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+    }
+}

--- a/tests/ValueTaskSupplement.Tests/WhenAnyTest_NonGenerics.cs
+++ b/tests/ValueTaskSupplement.Tests/WhenAnyTest_NonGenerics.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Xunit;
+
+namespace ValueTaskSupplement.Tests
+{
+    public class WhenAnyTest_NonGenerics
+    {
+        [Fact]
+        public async Task AnySync()
+        {
+            var a = CreateSync();
+            var b = CreateSync();
+            var c = CreateSync();
+            var result = await ValueTaskEx.WhenAny(a, b, c);
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task WithAsync()
+        {
+            var a = CreateAsync();
+            var b = CreateSync();
+            var c = CreateAsyncSlow();
+            var result = await ValueTaskEx.WhenAny(a, b, c);
+            result.Should().Be(1);
+        }
+
+        [Fact]
+        public async Task Array()
+        {
+            var a = CreateSync();
+            var b = CreateAsync();
+            var c = CreateAsyncSlow();
+            var result = await ValueTaskEx.WhenAny(new[] { a, b, c });
+            result.Should().Be(0);
+        }
+
+        [Fact]
+        public async Task Timeout()
+        {
+            {
+                var delay = Task.Delay(TimeSpan.FromMilliseconds(100));
+                var vtask = CreateAsync();
+                var index = await ValueTaskEx.WhenAny(vtask, delay);
+                index.Should().Be(0);
+            }
+            {
+                var delay = Task.Delay(TimeSpan.FromMilliseconds(100));
+                var vtask = CreateAsyncSlow();
+                var index = await ValueTaskEx.WhenAny(vtask, delay);
+                index.Should().Be(1);
+            }
+            {
+                var delay = Task.Delay(TimeSpan.FromMilliseconds(100));
+                var vtask = CreateSync();
+                var index = await ValueTaskEx.WhenAny(vtask, delay);
+                index.Should().Be(0);
+            }
+        }
+
+        ValueTask CreateSync()
+        {
+            return new ValueTask();
+        }
+
+        async ValueTask CreateAsync()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(10));
+        }
+
+        async ValueTask CreateAsyncSlow()
+        {
+            await Task.Delay(TimeSpan.FromMilliseconds(200));
+        }
+    }
+}


### PR DESCRIPTION
# Motivation
Currently, ValueTaskSupplement supports only `ValueTask<T>`. Just as CoreFx supports `Task` which is non generic APIs, ValueTaskSupplement should also support `ValueTask`.