### PR TITLE
Task -> ValueTask conversion

### DIFF
--- a/src/ValueTaskSupplement/ValueTaskEx.FromTask.cs
+++ b/src/ValueTaskSupplement/ValueTaskEx.FromTask.cs
@@ -1,0 +1,24 @@
+﻿using System.Threading.Tasks;
+
+
+
+namespace ValueTaskSupplement
+{
+    public static partial class ValueTaskEx
+    {
+        public static ValueTask FromTask(Task result)
+            => new ValueTask(result);
+
+
+        public static ValueTask<T> FromTask<T>(Task<T> result)
+            => new ValueTask<T>(result);
+
+
+        public static ValueTask AsValueTask(this Task result)
+            => new ValueTask(result);
+
+
+        public static ValueTask<T> AsValueTask<T>(this Task<T> result)
+            => new ValueTask<T>(result);
+    }
+}


### PR DESCRIPTION
# Motivation

Sometimes, we have to convert `Task` to `ValueTask`, because of type fitting. Just as CoreFx provides `ValueTask.AsTask()`, this library should provides inverse conversion.