### PR TITLE
ci: Cysharp/Actions/.github/workflows/create-release.yaml

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -12,10 +12,6 @@ on:
         default: false
         type: boolean
 
-env:
-  GIT_TAG: ${{ github.event.inputs.tag }}
-  DRY_RUN: ${{ github.event.inputs.dry-run }}
-
 jobs:
   build-dotnet:
     runs-on: ubuntu-latest
@@ -28,42 +24,21 @@ jobs:
             3.1.x
             6.0.x
       # pack nuget
-      - run: dotnet build -c Release -p:Version=${{ env.GIT_TAG }}
-      - run: dotnet test -c Release --no-build -p:Version=${{ env.GIT_TAG }}
-      - run: dotnet pack -c Release --no-build -p:Version=${{ env.GIT_TAG }} -o ./publish
+      - run: dotnet build -c Release -p:Version=${{ inputs.tag }}
+      - run: dotnet test -c Release --no-build -p:Version=${{ inputs.tag }}
+      - run: dotnet pack -c Release --no-build -p:Version=${{ inputs.tag }} -o ./publish
       - uses: actions/upload-artifact@v2
         with:
           name: nuget
           path: ./publish
 
   create-release:
-    if: github.event.inputs.dry-run == 'false'
     needs: [build-dotnet]
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: Cysharp/Actions/.github/actions/setup-dotnet@main
-      # tag
-      - uses: actions/checkout@v3
-      - name: tag
-        run: git tag ${{ env.GIT_TAG }}
-      - name: Push changes
-        uses: ad-m/github-push-action@master
-        with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          branch: ${{ github.ref }}
-          tags: true
-      # Create Releases
-      - uses: actions/create-release@v1
-        id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ env.GIT_TAG }}
-          release_name: Ver.${{ env.GIT_TAG }}
-          draft: true
-          prerelease: false
-      # Download (All) Artifacts to current directory
-      - uses: actions/download-artifact@v2
-      # Upload to NuGet
-      - run: dotnet nuget push "./nuget/*.nupkg" -s https://www.nuget.org/api/v2/package -k ${{ secrets.NUGET_KEY }}
+    uses: Cysharp/Actions/.github/workflows/create-release.yaml@main
+    with:
+      commit-id: ''
+      tag: ${{ inputs.tag }}
+      dry-run: ${{ inputs.dry-run }}
+      nuget-push: true
+      release-upload: false
+    secrets: inherit


### PR DESCRIPTION
## tl;dr;

Replace create-release with `Cysharp/Actions/.github/workflows/create-release.yaml`.

This brings central managed release flow control.

see: https://github.com/Cysharp/ValueTaskSupplement/actions/runs/7814551026