### PR TITLE
chore: Specify IsPackable=false on Directory.Build.props, explicitly true for target packages.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,7 +58,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -78,7 +78,19 @@ publish
 *.Publish.xml
 
 # NuGet Packages Directory
-packages
+*.nupkg
+# NuGet Symbol Packages
+*.snupkg
+# The packages folder can be ignored because of Package Restore
+# packages # upm pacakge will use Packages
+# **/[Pp]ackages/*
+# except build/, which is used as an MSBuild target.
+# !**/[Pp]ackages/build/
+# Uncomment if necessary however generally it will be regenerated when needed
+#!**/[Pp]ackages/repositories.config
+# NuGet v3's project.json files produces more ignorable files
+*.nuget.props
+*.nuget.targets
 
 # Windows Azure Build Output
 csx
@@ -113,10 +125,6 @@ src/MasterMemory.UnityClient/bin/*
 src/MasterMemory.UnityClient/Library/*
 src/MasterMemory.UnityClient/obj/*
 src/MasterMemory.UnityClient/Temp/*
-
-# OTHER
-nuget/tools/*
-*.nupkg
 
 .vs
 

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,6 +2,7 @@
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- NuGet Package Information -->
+    <IsPackable>false</IsPackable>
     <PackageVersion>$(Version)</PackageVersion>
     <Company>Cysharp</Company>
     <Authors>Cysharp</Authors>
@@ -16,7 +17,8 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
     <None Include="$(MSBuildThisFileDirectory)README.md" Pack="true" PackagePath="\" />
-		<None Include="$(MSBuildThisFileDirectory)Icon.png" Pack="true" PackagePath="\" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)LICENSE" />
   </ItemGroup>
 </Project>

--- a/sandbox/ConsoleApp/ConsoleApp.csproj
+++ b/sandbox/ConsoleApp/ConsoleApp.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ValueTaskSupplement/ValueTaskSupplement.csproj
+++ b/src/ValueTaskSupplement/ValueTaskSupplement.csproj
@@ -1,78 +1,79 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netstandard2.0</TargetFramework>
-        <LangVersion>8.0</LangVersion>
-        <Nullable>enable</Nullable>
-        <OutputType>Library</OutputType>
-        <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
-        <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <NoWarn>1701;1702;1705;1591</NoWarn>
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8.0</LangVersion>
+    <Nullable>enable</Nullable>
+    <OutputType>Library</OutputType>
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>1701;1702;1705;1591</NoWarn>
 
-        <!-- NuGet -->
-        <PackageId>ValueTaskSupplement</PackageId>
-        <Description>Append supplemental methods(WhenAny, WhenAll, Lazy) to ValueTask.</Description>
-    </PropertyGroup>
+    <!-- NuGet -->
+    <IsPackable>true</IsPackable>
+    <PackageId>ValueTaskSupplement</PackageId>
+    <Description>Append supplemental methods(WhenAny, WhenAll, Lazy) to ValueTask.</Description>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="System.Buffers" Version="4.5.0" />
-        <PackageReference Include="System.Memory" Version="4.5.3" />
-        <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.0" />
+    <PackageReference Include="System.Memory" Version="4.5.3" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.3" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <None Update="ValueTaskEx.WhenAll.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ValueTaskEx.WhenAll.cs</LastGenOutput>
-        </None>
-        <None Update="ValueTaskEx.WhenAll_NonGenerics.tt">
-            <LastGenOutput>ValueTaskEx.WhenAll_NonGenerics.cs</LastGenOutput>
-            <Generator>TextTemplatingFileGenerator</Generator>
-        </None>
-        <None Update="ValueTaskEx.WhenAny.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ValueTaskEx.WhenAny.cs</LastGenOutput>
-        </None>
-        <None Update="ValueTaskEx.WhenAny_NonGenerics.tt">
-            <LastGenOutput>ValueTaskEx.WhenAny_NonGenerics.cs</LastGenOutput>
-            <Generator>TextTemplatingFileGenerator</Generator>
-        </None>
-        <None Update="ValueTaskWhenAllExtensions.tt">
-            <Generator>TextTemplatingFileGenerator</Generator>
-            <LastGenOutput>ValueTaskWhenAllExtensions.cs</LastGenOutput>
-        </None>
-    </ItemGroup>
+  <ItemGroup>
+    <None Update="ValueTaskEx.WhenAll.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ValueTaskEx.WhenAll.cs</LastGenOutput>
+    </None>
+    <None Update="ValueTaskEx.WhenAll_NonGenerics.tt">
+      <LastGenOutput>ValueTaskEx.WhenAll_NonGenerics.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="ValueTaskEx.WhenAny.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ValueTaskEx.WhenAny.cs</LastGenOutput>
+    </None>
+    <None Update="ValueTaskEx.WhenAny_NonGenerics.tt">
+      <LastGenOutput>ValueTaskEx.WhenAny_NonGenerics.cs</LastGenOutput>
+      <Generator>TextTemplatingFileGenerator</Generator>
+    </None>
+    <None Update="ValueTaskWhenAllExtensions.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>ValueTaskWhenAllExtensions.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Compile Update="ValueTaskEx.WhenAll.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAll.tt</DependentUpon>
-        </Compile>
-        <Compile Update="ValueTaskEx.WhenAll_NonGenerics.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAll_NonGenerics.tt</DependentUpon>
-        </Compile>
-        <Compile Update="ValueTaskEx.WhenAny.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAny.tt</DependentUpon>
-        </Compile>
-        <Compile Update="ValueTaskEx.WhenAny_NonGenerics.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskEx.WhenAny_NonGenerics.tt</DependentUpon>
-        </Compile>
-        <Compile Update="ValueTaskWhenAllExtensions.cs">
-            <DesignTime>True</DesignTime>
-            <AutoGen>True</AutoGen>
-            <DependentUpon>ValueTaskWhenAllExtensions.tt</DependentUpon>
-        </Compile>
-    </ItemGroup>
+  <ItemGroup>
+    <Compile Update="ValueTaskEx.WhenAll.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTaskEx.WhenAll.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ValueTaskEx.WhenAll_NonGenerics.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTaskEx.WhenAll_NonGenerics.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ValueTaskEx.WhenAny.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTaskEx.WhenAny.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ValueTaskEx.WhenAny_NonGenerics.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTaskEx.WhenAny_NonGenerics.tt</DependentUpon>
+    </Compile>
+    <Compile Update="ValueTaskWhenAllExtensions.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>ValueTaskWhenAllExtensions.tt</DependentUpon>
+    </Compile>
+  </ItemGroup>
 
-    <ItemGroup>
-        <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
-    </ItemGroup>
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
 
 </Project>

--- a/tests/ValueTaskSupplement.Tests/ValueTaskSupplement.Tests.csproj
+++ b/tests/ValueTaskSupplement.Tests/ValueTaskSupplement.Tests.csproj
@@ -2,8 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
-
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

Change IsPackable from default, implicitly `true`, to explicitly `false`.
This prevent unintended nuget package generation like sandbox, benchmark, and etc....

Side effect:

- nupkg csproj required to specify `<IsPackable>true</IsPackable>`. Previously they are omitted.
- LICENSE.md is now handled by Directory.Build.props
